### PR TITLE
Fix NOS feeds

### DIFF
--- a/nederland24.py
+++ b/nederland24.py
@@ -171,13 +171,15 @@ def additionalChannels(url, depth):
     # URL = 'http://feeds.nos.nl/journaal'
     items = SoupStrainer('item')
     for tag in BeautifulStoneSoup(urllib2.urlopen(URL).read(), parseOnlyThese=items):
-        title = tag.title.contents[0]
-        url = tag.find('media:content')['url']
-        img = os.path.join(IMG_DIR, "npo_placeholder.png")
-        addLink(title, url, "playVideo", img, '')
-        i += 1
-        if i == int(depth):
-            break
+        try:
+            title = tag.title.contents[0]
+            url = tag.find('media:content')['url']
+            img = os.path.join(IMG_DIR, "npo_placeholder.png")
+            addLink(title, url, "playVideo", img, '')
+        finally:
+            i += 1
+            if i == int(depth):
+                break
 
 
 def playVideo(url):

--- a/nederland24.py
+++ b/nederland24.py
@@ -172,7 +172,7 @@ def additionalChannels(url, depth):
     items = SoupStrainer('item')
     for tag in BeautifulStoneSoup(urllib2.urlopen(URL).read(), parseOnlyThese=items):
         title = tag.title.contents[0]
-        url = tag.guid.contents[0]
+        url = tag.find('media:content')['url']
         img = os.path.join(IMG_DIR, "npo_placeholder.png")
         addLink(title, url, "playVideo", img, '')
         i += 1


### PR DESCRIPTION
I presumed the NOS journaal links added to the menu should be directly to the video itself instead of the embedding page.
The second commit merely prevents choking on incomplete feed entries and stopping halfway down the feed list.